### PR TITLE
Add Opera extension build

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ These instructions have been designed and tested for a clean local machine envir
    npm run build
    # Or run directly: bash build.sh
    ```
-   *This will create a `dist/` directory containing `chrome/`, `firefox/`, and `edge/` builds.*
+   *This will create a `dist/` directory containing `chrome/`, `firefox/`, `edge/`, and `opera/` builds.*
 
 4. **Load the extension manually into your browser:**
    * **For Chrome:** Navigate to `chrome://extensions/`, toggle on "Developer mode" in the top right, click "Load unpacked", and select the `dist/chrome/` folder.
    * **For Edge:** Navigate to `edge://extensions/`, toggle on "Developer mode", click "Load unpacked", and select `dist/edge/`.
+   * **For Opera:** Navigate to `opera://extensions/`, toggle on "Developer mode", click "Load unpacked", and select `dist/opera/`.
    * **For Firefox:** Navigate to `about:debugging#/runtime/this-firefox`, click "Load Temporary Add-on", and select the `manifest.json` inside the `dist/firefox/` folder.
 
 ---

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # Clean previous builds
 rm -rf dist
-mkdir -p dist/firefox dist/chrome dist/edge
+mkdir -p dist/firefox dist/chrome dist/edge dist/opera
 
 # --- BUILD FIREFOX ---
 cp -r src/* dist/firefox/
@@ -19,5 +19,11 @@ cd dist/chrome && zip -r ../ytm-mini-chrome.zip * -x "*.DS_Store" && cd ../..
 cp -r src/* dist/edge/
 cp manifest.chrome.json dist/edge/manifest.json
 cd dist/edge && zip -r ../ytm-mini-edge.zip * -x "*.DS_Store" && cd ../..
+
+# --- BUILD OPERA ---
+# Opera supports Chrome-compatible MV3 extensions, so it uses the same manifest.
+cp -r src/* dist/opera/
+cp manifest.chrome.json dist/opera/manifest.json
+cd dist/opera && zip -r ../ytm-mini-opera.zip * -x "*.DS_Store" && cd ../..
 
 echo "Build Complete! Check the /dist folder."


### PR DESCRIPTION
This adds an Opera build target alongside the existing Firefox, Chrome, and Edge packages. Opera supports Chrome-compatible MV3 extensions, so the build reuses the Chrome manifest while producing a separate dist/opera folder and ytm-mini-opera.zip package. The README now includes Opera in the generated build list and manual loading instructions.