### PR TITLE
Fix standalone PWA Mini Mode behavior

### DIFF
--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -10,7 +10,7 @@
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
   },
-  "permissions": [],
+ "permissions": ["storage"],
   "host_permissions": ["*://music.youtube.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -10,7 +10,7 @@
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
   },
-  "permissions": [],
+ "permissions": ["storage"],
   "host_permissions": ["*://music.youtube.com/*"],
   "background": {
     "scripts": ["background.js"]

--- a/src/background.js
+++ b/src/background.js
@@ -1,9 +1,5 @@
 // background.js
 
-/**
- * 1. Robust Polyfill Initialization
- * Ensures 'browser' namespace is available, falling back to 'chrome' if necessary.
- */
 try {
     if (typeof importScripts === "function") {
         importScripts("browser-polyfill.min.js");
@@ -12,19 +8,103 @@ try {
     console.warn("Background: Polyfill import skipped or failed:", e);
 }
 
-// Fallback for environments where polyfill might not have attached to global scope correctly
 const messenger = typeof browser !== "undefined" ? browser : chrome;
+const MINI_WINDOW_BOUNDS = { width: 380, height: 700 };
+const PWA_STATE_KEY = "ytmMiniPwaTabs";
 
-/**
- * 2. Message Listener
- * Handles the 'toggle_mini' action to switch between normal and popup windows.
- */
+function removeUndefinedValues(bounds) {
+    return Object.fromEntries(Object.entries(bounds).filter(([, value]) => value !== undefined));
+}
+
+async function getPwaWindowStates() {
+    if (!messenger.storage || !messenger.storage.local) {
+        return {};
+    }
+
+    const result = await messenger.storage.local.get(PWA_STATE_KEY);
+    return result[PWA_STATE_KEY] || {};
+}
+
+async function setPwaWindowStates(states) {
+    if (!messenger.storage || !messenger.storage.local) {
+        return;
+    }
+
+    await messenger.storage.local.set({ [PWA_STATE_KEY]: states });
+}
+
+function getRestorableBounds(windowInfo) {
+    return removeUndefinedValues({
+        left: windowInfo.left,
+        top: windowInfo.top,
+        width: windowInfo.width,
+        height: windowInfo.height,
+        state: windowInfo.state,
+    });
+}
+
+function getRestoreUpdateInfo(bounds) {
+    const focused = true;
+
+    if (bounds.state && bounds.state !== "normal") {
+        return { state: bounds.state, focused };
+    }
+
+    return {
+        ...bounds,
+        state: "normal",
+        focused,
+    };
+}
+
+async function cleanupPwaWindowStates({ tabId, windowId }) {
+    const states = await getPwaWindowStates();
+    let changed = false;
+
+    for (const [savedTabId, savedState] of Object.entries(states)) {
+        if (
+            (tabId !== undefined && Number(savedTabId) === tabId) ||
+            (windowId !== undefined && savedState.windowId === windowId)
+        ) {
+            delete states[savedTabId];
+            changed = true;
+        }
+    }
+
+    if (changed) {
+        await setPwaWindowStates(states);
+    }
+}
+
+async function toggleStandalonePwaWindow(currentWindow, tabId) {
+    const states = await getPwaWindowStates();
+    const savedState = states[String(tabId)];
+
+    if (savedState && savedState.windowId === currentWindow.id) {
+        delete states[String(tabId)];
+        await setPwaWindowStates(states);
+        await messenger.windows.update(currentWindow.id, getRestoreUpdateInfo(savedState.bounds));
+        return;
+    }
+
+    states[String(tabId)] = {
+        windowId: currentWindow.id,
+        bounds: getRestorableBounds(currentWindow),
+    };
+
+    await setPwaWindowStates(states);
+    await messenger.windows.update(currentWindow.id, {
+        state: "normal",
+        ...MINI_WINDOW_BOUNDS,
+        focused: true,
+    });
+}
+
 messenger.runtime.onMessage.addListener(async (message, sender) => {
     if (message.action === "toggle_mini") {
         console.log("Background: Received toggle_mini request");
 
-        // Safety check: Ensure we have a valid tab to move
-        if (!sender.tab || !sender.tab.id) {
+        if (!sender.tab || typeof sender.tab.id !== "number") {
             console.error("Background: No tab information in sender context.");
             return;
         }
@@ -32,34 +112,47 @@ messenger.runtime.onMessage.addListener(async (message, sender) => {
         try {
             const currentWindow = await messenger.windows.get(sender.tab.windowId);
 
-            if (currentWindow.type === "popup") {
+            if (message.isStandalonePwa) {
+                console.log("Background: Toggling standalone PWA window size...");
+                await toggleStandalonePwaWindow(currentWindow, sender.tab.id);
+            } else if (currentWindow.type === "popup") {
                 console.log("Background: Reverting to main window...");
                 const normalWindows = await messenger.windows.getAll({ windowTypes: ["normal"] });
 
                 if (normalWindows.length > 0) {
-                    // Move tab back to the first available normal window
                     await messenger.tabs.move(sender.tab.id, { windowId: normalWindows[0].id, index: -1 });
                     await messenger.tabs.update(sender.tab.id, { active: true });
                     await messenger.windows.update(normalWindows[0].id, { focused: true });
                 } else {
-                    // Create a new normal window if none exist
                     await messenger.windows.create({ tabId: sender.tab.id, type: "normal" });
                 }
             } else {
                 console.log("Background: Entering Mini Mode...");
-                // Create the popup window
-                // Note: Edge sometimes requires 'focused: true' to be explicitly set for the new window to appear
                 await messenger.windows.create({
                     tabId: sender.tab.id,
                     type: "popup",
-                    width: 380,
-                    height: 700,
+                    ...MINI_WINDOW_BOUNDS,
                     focused: true,
                 });
             }
         } catch (error) {
             console.error("Background: Failed to toggle window.", error);
-            // In case of a failure, we could notify the content script here if needed
         }
     }
 });
+
+if (messenger.tabs && messenger.tabs.onRemoved) {
+    messenger.tabs.onRemoved.addListener((tabId) => {
+        cleanupPwaWindowStates({ tabId }).catch((error) => {
+            console.error("Background: Failed to clean up PWA tab state.", error);
+        });
+    });
+}
+
+if (messenger.windows && messenger.windows.onRemoved) {
+    messenger.windows.onRemoved.addListener((windowId) => {
+        cleanupPwaWindowStates({ windowId }).catch((error) => {
+            console.error("Background: Failed to clean up PWA window state.", error);
+        });
+    });
+}

--- a/src/content.js
+++ b/src/content.js
@@ -102,6 +102,14 @@ let isDragging = false;
 let startX, startY, initialX, initialY;
 let originalParent = null;
 let originalSibling = null;
+function isStandalonePwaWindow() {
+    const standaloneDisplayModes = ["standalone", "window-controls-overlay", "minimal-ui"];
+
+    return (
+        standaloneDisplayModes.some((displayMode) => window.matchMedia(`(display-mode: ${displayMode})`).matches) ||
+        window.navigator.standalone === true
+    );
+}
 
 function initDraggable(el) {
     el.addEventListener("mousedown", dragStart);
@@ -320,7 +328,9 @@ function createNavButtons() {
         const messenger = typeof browser !== "undefined" ? browser : chrome;
 
         try {
-            messenger.runtime.sendMessage({ action: "toggle_mini" }).catch((err) => {
+           messenger.runtime
+                .sendMessage({ action: "toggle_mini", isStandalonePwa: isStandalonePwaWindow() })
+                .catch((err) => {
                 console.error("YTM Mini: Failed to send message.", err);
             });
         } catch (err) {


### PR DESCRIPTION
## Summary

This PR fixes Mini Mode behavior when YouTube Music is running as a standalone PWA.

Previously, toggling Mini Mode from a PWA moved the player into a browser popup window, causing it to lose its standalone app behavior and disappear from the OS app switcher.

### Changes

* Added standalone PWA detection in content script.
* Added storage permission for persisting window state.
* Updated background window management logic to resize and restore standalone PWA windows instead of moving tabs between windows.
* Added cleanup for stored PWA window state.

### Result

Mini Mode now preserves the standalone PWA window and restores its original size when toggled off.
