### PR TITLE
docs: remove authuser parameter from Chrome extension link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A lightweight, distraction-free mini-player extension for YouTube Music, availab
 
 <a href="https://microsoftedge.microsoft.com/addons/detail/ytm-mini-mode/cccmmkfhbjgchhgfacbllhkpgblfaodj"><img src="https://user-images.githubusercontent.com/585534/107280673-a5ece780-6a26-11eb-9cc7-9fa9f9f81180.png" alt="Get YTM Mini Mode for Microsoft Edge" height="40"></a>
 
-<a href="https://chromewebstore.google.com/detail/ytm-mini-mode/lpfejlnnjobhdpbhdlmhmmhhmphhbdda?authuser=2&hl=en"><img src="https://user-images.githubusercontent.com/585534/107280622-91a8ea80-6a26-11eb-8d07-77c548b28665.png" alt="Get YTM Mini Mode for Chrome" height="40"></a>
+<a href="https://chromewebstore.google.com/detail/ytm-mini-mode/lpfejlnnjobhdpbhdlmhmmhhmphhbdda"><img src="https://user-images.githubusercontent.com/585534/107280622-91a8ea80-6a26-11eb-8d07-77c548b28665.png" alt="Get YTM Mini Mode for Chrome" height="40"></a>
 
 ## 📖 Project Purpose
 


### PR DESCRIPTION
Summary
Removed the ?authuser=2&hl=en query parameter from the Chrome Web Store installation link in the README.md.

Why it is needed: The authuser=2 parameter forces the browser to attempt opening the link using the second logged-in Google profile on the user's machine. For users who only have one profile, or who aren't logged in, this can result in a 404 error, a redirect loop, or an unwanted login prompt. Stripping this parameter ensures the link is completely universal and works perfectly for everyone.

Fixes : #43
Testing
Verified the clean URL (https://chromewebstore.google.com/detail/ytm-mini-mode/lpfejlnnjobhdpbhdlmhmmhhmphhbdda) resolves directly to the correct extension page in a fresh/incognito browser window without prompting for specific account authentication.

Checklist
[x] I have tested the change locally.

[x] I have updated documentation if needed.
