### PR TITLE
fix: add missing tabs permission to manifests for tabs.move and tabs.…

### DIFF
--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -10,7 +10,7 @@
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
   },
-  "permissions": [],
+  "permissions": ["tabs"],
   "host_permissions": ["*://music.youtube.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -10,7 +10,7 @@
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
   },
-  "permissions": [],
+  "permissions": ["tabs"],
   "host_permissions": ["*://music.youtube.com/*"],
   "background": {
     "scripts": ["background.js"]

--- a/src/background.js
+++ b/src/background.js
@@ -77,7 +77,9 @@ messenger.runtime.onMessage.addListener(async (message, sender) => {
                     const normalWindows = await messenger.windows.getAll({ windowTypes: ["normal"] });
 
                     if (normalWindows.length > 0) {
-                        // Move tab back to the first available normal window
+                        // Note: tabs.move() and tabs.update() require the "tabs" permission
+                        // in the manifest. Do NOT remove that permission — these calls will
+                        // silently fail without it on Chrome and throw errors on Firefox.
                         await messenger.tabs.move(sender.tab.id, { windowId: normalWindows[0].id, index: -1 });
                         await messenger.tabs.update(sender.tab.id, { active: true });
                         await messenger.windows.update(normalWindows[0].id, { focused: true });


### PR DESCRIPTION
## What does this PR do?
Adds the missing `"tabs"` permission to both `manifest.chrome.json` and
`manifest.firefox.json`. This permission is required for `tabs.move()` and
`tabs.update()` calls in `src/background.js` that handle reverting the tab
from the popup mini window back to a normal browser window.

## Why was this broken?
The `tabs` permission was removed in v1.3.1 (see CONTEXT.md) but the API
calls that depend on it were not replaced. Without this permission, browsers
silently drop or throw errors on `tabs.move` and `tabs.update`, causing the
exit-mini-mode flow to fail inconsistently, especially on Firefox.

## Files Changed
- `manifest.chrome.json` — added `"tabs"` to permissions array
- `manifest.firefox.json` — added `"tabs"` to permissions array
- `src/background.js` — added comment to explain why tabs permission is needed

## How to Test
1. Build with `npm run build`
2. Load `dist/chrome/` in Chrome as an unpacked extension
3. Open music.youtube.com → enter mini mode → exit mini mode
4. Tab should return to the normal window correctly on both Chrome and Firefox

## Related Issue
Closes #49 