### PR TITLE
fix: derive mini mode state from window type instead of sessionStorage

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -20,6 +20,21 @@ const messenger = typeof browser !== "undefined" ? browser : chrome;
  * Handles the 'toggle_mini' action to switch between normal and popup windows.
  */
 messenger.runtime.onMessage.addListener(async (message, sender) => {
+    // New handler: content.js asks "what type is my current window?"
+    // This lets content.js derive mini mode state from reality, not sessionStorage
+    if (message.action === "get_window_type") {
+        if (!sender.tab || !sender.tab.windowId) {
+            return { windowType: "normal" }; // safe fallback
+        }
+        try {
+            const win = await messenger.windows.get(sender.tab.windowId);
+            return { windowType: win.type };
+        } catch (e) {
+            console.warn("Background: get_window_type failed", e);
+            return { windowType: "normal" }; // safe fallback
+        }
+    }
+
     if (message.action === "toggle_mini") {
         console.log("Background: Received toggle_mini request");
 
@@ -29,8 +44,14 @@ messenger.runtime.onMessage.addListener(async (message, sender) => {
             return;
         }
 
-        try {
+         try {
             const currentWindow = await messenger.windows.get(sender.tab.windowId);
+
+            // Send the actual window type back to content.js so it can
+            // derive mini mode state from reality, not from sessionStorage
+            if (message.action === "get_window_type") {
+                return { windowType: currentWindow.type };
+            }
             const isPWA = message.matchesStandalone && currentWindow.type !== "popup";
 
             if (isPWA) {

--- a/src/content.js
+++ b/src/content.js
@@ -300,7 +300,7 @@ function createNavButtons() {
     mainBtn.onmouseover = () => (mainBtn.style.backgroundColor = "rgba(255, 255, 255, 0.1)");
     mainBtn.onmouseout = () => (mainBtn.style.backgroundColor = "transparent");
 
-    mainBtn.addEventListener("click", (e) => {
+    mainBtn.addEventListener("click", async(e) => {
         // Prevent event from bubbling up to YTM's own listeners
         e.preventDefault();
         e.stopPropagation();
@@ -319,12 +319,22 @@ function createNavButtons() {
         // Use fallback-safe messenger
         const messenger = typeof browser !== "undefined" ? browser : chrome;
 
-        try {
+       try {
             const matchesStandalone = !window.toolbar.visible || window.matchMedia("(display-mode: standalone)").matches || window.matchMedia("(display-mode: minimal-ui)").matches;
+
+            // Ask background script what type the current window actually is.
+            // This is always accurate — avoids stale sessionStorage state after
+            // tab crash/restore or extension reload.
             let inMiniMode = false;
             try {
-                inMiniMode = sessionStorage.getItem("ytm_in_mini_mode") === "true";
-            } catch {}
+                const response = await messenger.runtime.sendMessage({ action: "get_window_type" });
+                inMiniMode = response?.windowType === "popup";
+            } catch {
+                // Fallback: if messaging fails, read sessionStorage as last resort
+                try {
+                    inMiniMode = sessionStorage.getItem("ytm_in_mini_mode") === "true";
+                } catch {}
+            }
 
             const isEntering = !inMiniMode;
             const message = { action: "toggle_mini", matchesStandalone, isEntering };


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where mini mode state becomes stale after a tab crash/restore
or extension reload, causing the toggle button to behave incorrectly.

## Root Cause

The old code determined mini mode state from `sessionStorage`:

```js
inMiniMode = sessionStorage.getItem("ytm_in_mini_mode") === "true";
```

If the tab crashed and was restored, `sessionStorage` retained the old
`true` value even though the window was now normal again. This caused the
toggle to try exiting mini mode when it should be entering.

Additionally, `sessionStorage` is blocked in strict privacy settings,
with no reliable recovery in the existing catch block.

## Fix

Added a `get_window_type` message handler in `background.js` that returns
the actual window type via `messenger.windows.getCurrent()`.

In `content.js`, the click handler now sends this message first and derives
`inMiniMode` from the real window type (`"popup"` = in mini mode).
`sessionStorage` is kept only as a last-resort fallback if messaging fails.

## Files Changed
- `src/background.js` — added `get_window_type` message handler
- `src/content.js` — click handler made `async`, state derived from window type

## How to Test
1. `npm run build`
2. Load `dist/chrome/` as unpacked extension
3. Enter mini mode → clear sessionStorage manually in DevTools
4. Click toggle → should correctly EXIT mini mode (reads window type, not storage)
5. Enter mini mode → reload extension → click toggle → correct state ✅

Closes #47 