### PR TITLE
devops: auto-assign workflow

### DIFF
--- a/.github/workflows/issue-assign.yml
+++ b/.github/workflows/issue-assign.yml
@@ -1,0 +1,128 @@
+name: Issue Assignment
+
+on:
+  issues:
+    types: [opened]
+    
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  assign:
+    name: Auto-assign contributor
+    runs-on: ubuntu-latest
+
+    # Serialize runs for the same issue to prevent race conditions
+    concurrency:
+      group: issue-assign-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    
+    # Skip pull request comments/events (only process real issues)
+    if: github.event.issue.pull_request == null
+
+    steps:
+      - name: Handle assignment request
+        uses: actions/github-script@v7
+        
+        with:
+          script: |
+            const isComment = !!context.payload.comment;
+            const targetUser = isComment ? context.payload.comment.user.login : context.payload.issue.user.login;
+            const userType = isComment ? context.payload.comment.user.type : context.payload.issue.user.type;
+
+            // Skip automated bot comments/issues
+            if (userType === 'Bot') return;
+
+            const commentText = (context.payload.comment?.body || '').toLowerCase().trim();
+            const issueBody = (context.payload.issue?.body || '').toLowerCase().trim();
+            const issueTitle = (context.payload.issue?.title || '').toLowerCase().trim();
+
+            const KEYWORDS = [
+              "assign",
+              "/assign",
+              "assigned",
+              "assignee",
+              "assigning",
+              "assignment",
+              "assign me",
+              "please assign me",
+              "claim",
+              "take",
+              "work on",
+              "i'd like to work on this",
+              "i want to work on this",
+              "can i work on this",
+              "i will work on this",
+              "i'll work on this",
+              "i'll handle this",
+              "dibs"
+            ];
+
+            const matchesAssignment = (text) => {
+              if (!text) return false;
+              return KEYWORDS.some(kw => text.includes(kw)) || /\bassign\w*/i.test(text);
+            };
+
+            // 1. Check if assignment request exists either in description or comment
+            const isAssignmentRequested = matchesAssignment(commentText) || matchesAssignment(issueBody) || matchesAssignment(issueTitle);
+            if (!isAssignmentRequested) return;
+
+            const { owner, repo } = context.repo;
+            const issueNumber = context.payload.issue.number;
+
+            // 2. Fetch live issue data from the GitHub API
+            const { data: issue } = await github.rest.issues.get({
+              owner, repo, issue_number: issueNumber,
+            });
+
+            if (issue.state !== 'open') return;
+
+            // 3. Check if the issue is already taken
+            if (issue.assignees && issue.assignees.length > 0) {
+              const assignees = issue.assignees.map(a => a.login);
+              
+              if (assignees.includes(targetUser)) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: issueNumber,
+                  body: `@${targetUser} You are already assigned to this issue! Please link your upcoming Pull Request to this ticket.`,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: issueNumber,
+                  body: `@${targetUser} This issue is already claimed by @${assignees.join(', @')}. Keep an eye out for other open tasks!`,
+                });
+              }
+              return;
+            }
+
+            // 4. Assign the contributor
+            await github.rest.issues.addAssignees({
+              owner, repo, issue_number: issueNumber,
+              assignees: [targetUser],
+            });
+
+            // 5. Verify GitHub successfully added the assignee (handles non-collaborator silent drops)
+            const { data: updatedIssue } = await github.rest.issues.get({
+              owner, repo, issue_number: issueNumber,
+            });
+
+            const currentAssignees = updatedIssue.assignees.map(a => a.login);
+            if (!currentAssignees.includes(targetUser)) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNumber,
+                body: `@${targetUser} Unable to assign you automatically. A repository administrator may need to assign you manually.`,
+              });
+              return;
+            }
+
+            // 6. Post confirmation comment
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issueNumber,
+              body: `Assigned to @${targetUser}! Please open a Pull Request linking to this issue once ready.`,
+            });
+
+
+            


### PR DESCRIPTION
## Summary

Currently, maintainers or contributors have to manually assign themselves or others to issues. By introducing an automated workflow that triggers on an issue comment (like /assign or assignment or many other keywords in pr), anyone can automatically assign the issue to themselves with a simple keyword.

## Testing
proof of working
- i tested it on my fork and attaching screenshot of it
<img width="1321" height="757" alt="image" src="https://github.com/user-attachments/assets/cd551b2d-7823-4b6b-bdb6-d4a5d28a293d" />


## Checklist

- I have tested the change locally.
- I have updated documentation if needed.

closes #65 