### PR TITLE
chore: fix formatting scripts and format codebase

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,53 +2,60 @@
 
 ## Our Pledge
 
-We as contributors, maintainers, and community members pledge to make participation in this project a welcoming, respectful, inclusive, and harassment-free experience for everyone, regardless of age, nationality, ethnicity, disability, gender identity and expression, religion, level of experience, or background.
+We as contributors, maintainers, and community members pledge to make participation in this project a welcoming,
+respectful, inclusive, and harassment-free experience for everyone, regardless of age, nationality, ethnicity,
+disability, gender identity and expression, religion, level of experience, or background.
 
-We are committed to fostering a collaborative environment where contributors can work together to build lightweight, privacy-friendly, and user-focused browser extensions.
+We are committed to fostering a collaborative environment where contributors can work together to build lightweight,
+privacy-friendly, and user-focused browser extensions.
 
 ## Our Standards
 
 Examples of behavior that contribute to a positive environment include:
 
-* Treating others with respect and professionalism.
-* Providing constructive feedback and accepting feedback gracefully.
-* Supporting contributors of all experience levels.
-* Sharing knowledge and helping others learn.
-* Collaborating openly on improvements and bug fixes.
-* Supporting the growth of the project.
+- Treating others with respect and professionalism.
+- Providing constructive feedback and accepting feedback gracefully.
+- Supporting contributors of all experience levels.
+- Sharing knowledge and helping others learn.
+- Collaborating openly on improvements and bug fixes.
+- Supporting the growth of the project.
 
 Examples of unacceptable behavior include:
 
-* Harassment, discrimination, or hateful conduct.
-* Personal attacks, intimidation, or trolling.
-* Publishing private information without permission.
-* Deliberately introducing malicious code or security vulnerabilities.
-* Misrepresenting another contributor's work.
-* Any conduct that creates a hostile or unwelcoming environment.
+- Harassment, discrimination, or hateful conduct.
+- Personal attacks, intimidation, or trolling.
+- Publishing private information without permission.
+- Deliberately introducing malicious code or security vulnerabilities.
+- Misrepresenting another contributor's work.
+- Any conduct that creates a hostile or unwelcoming environment.
 
 ## Privacy and User Experience
 
 As this project is a browser extension designed to enhance the YouTube Music experience, contributors are expected to:
 
-* Respect user privacy and security.
-* Avoid collecting unnecessary user data.
-* Clearly communicate any permission requirements.
-* Prioritize performance, accessibility, and usability.
-* Follow responsible development practices.
+- Respect user privacy and security.
+- Avoid collecting unnecessary user data.
+- Clearly communicate any permission requirements.
+- Prioritize performance, accessibility, and usability.
+- Follow responsible development practices.
 
 ## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying and enforcing community standards and may take appropriate action when necessary.
+Project maintainers are responsible for clarifying and enforcing community standards and may take appropriate action
+when necessary.
 
-Maintainers reserve the right to remove, edit, or reject comments, commits, issues, pull requests, and other contributions that do not align with this Code of Conduct.
+Maintainers reserve the right to remove, edit, or reject comments, commits, issues, pull requests, and other
+contributions that do not align with this Code of Conduct.
 
 ## Scope
 
-This Code of Conduct applies to all project spaces, including GitHub repositories, issues, pull requests, discussions, documentation, and community communication channels related to this project.
+This Code of Conduct applies to all project spaces, including GitHub repositories, issues, pull requests, discussions,
+documentation, and community communication channels related to this project.
 
 ## Enforcement
 
-Instances of unacceptable behavior may be reported to the project maintainers through official project communication channels.
+Instances of unacceptable behavior may be reported to the project maintainers through official project communication
+channels.
 
 All reports will be reviewed and handled respectfully and confidentially whenever possible.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,8 +1,8 @@
 # Project Context — YTM Mini Mode
 
-> This file provides structured context for LLM-assisted development on this project.
-> It covers architecture, file roles, conventions, browser differences, and contribution guidelines.
-> Keep this file updated when the project structure or conventions change.
+> This file provides structured context for LLM-assisted development on this project. It covers architecture, file
+> roles, conventions, browser differences, and contribution guidelines. Keep this file updated when the project
+> structure or conventions change.
 
 ---
 
@@ -11,10 +11,13 @@
 **YTM Mini Mode** is a cross-browser extension for YouTube Music (`music.youtube.com`).
 
 It injects a toggle button into the YouTube Music UI. When clicked:
-1. The current YTM tab is popped out into a small, floating mini-window using the browser's native `window` APIs.
-2. Clicking the toggle again collapses the mini-window back into the main browser session — **without interrupting playback**.
 
-No custom audio player is built. The extension simply **repositions the existing YouTube Music tab** into a smaller window frame.
+1. The current YTM tab is popped out into a small, floating mini-window using the browser's native `window` APIs.
+2. Clicking the toggle again collapses the mini-window back into the main browser session — **without interrupting
+   playback**.
+
+No custom audio player is built. The extension simply **repositions the existing YouTube Music tab** into a smaller
+window frame.
 
 ---
 
@@ -45,12 +48,12 @@ ytm-miniplayer/
 
 The `src/` folder contains the actual extension logic. Key files to expect:
 
-| File | Role |
-|------|------|
-| `content.js` | Injected into `music.youtube.com`. Adds the toggle button to the DOM, handles click events. |
+| File            | Role                                                                                                                                      |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `content.js`    | Injected into `music.youtube.com`. Adds the toggle button to the DOM, handles click events.                                               |
 | `background.js` | Service worker (MV3) or background page (MV2). Manages `chrome.windows` / `browser.windows` API calls to pop out and collapse the window. |
-| `browser-polyfill.min.js'
-| `icons` |  
+
+| `browser-polyfill.min.js' | `icons` |
 
 ---
 
@@ -74,7 +77,8 @@ background.js calls browser.windows.remove() or moves tab back
 into the original window using browser.tabs.move()
 ```
 
-All browser API calls go through **`webextension-polyfill`**, which normalizes the `chrome.*` and `browser.*` API differences so the same JS works on both Chrome and Firefox.
+All browser API calls go through **`webextension-polyfill`**, which normalizes the `chrome.*` and `browser.*` API
+differences so the same JS works on both Chrome and Firefox.
 
 ---
 
@@ -82,16 +86,17 @@ All browser API calls go through **`webextension-polyfill`**, which normalizes t
 
 This project maintains **two separate manifests**:
 
-| | `manifest.chrome.json` | `manifest.firefox.json` |
-|---|---|---|
-| Version | Manifest V3 | Manifest V2 |
-| Background | `service_worker` | `scripts` array (persistent background page) |
-| Browser Action | `action` | `browser_action` |
-| Target | Chrome, Edge | Firefox |
+|                | `manifest.chrome.json` | `manifest.firefox.json`                      |
+| -------------- | ---------------------- | -------------------------------------------- |
+| Version        | Manifest V3            | Manifest V2                                  |
+| Background     | `service_worker`       | `scripts` array (persistent background page) |
+| Browser Action | `action`               | `browser_action`                             |
+| Target         | Chrome, Edge           | Firefox                                      |
 
 The `build.sh` script copies the right manifest as `manifest.json` into each browser's `dist/` folder.
 
-**Firefox MV3 note:** Firefox has begun supporting Manifest V3 but with differences from Chrome's MV3 implementation. Migration is a known future task.
+**Firefox MV3 note:** Firefox has begun supporting Manifest V3 but with differences from Chrome's MV3 implementation.
+Migration is a known future task.
 
 ---
 
@@ -106,11 +111,13 @@ bash build.sh
 ```
 
 **What `build.sh` does:**
+
 1. Copies `src/` into `dist/chrome/`, `dist/firefox/`, and `dist/edge/`
 2. Places the correct manifest into each folder
 3. Output in `dist/` is store-ready and `.gitignore`d
 
 **Dev tooling (npm) is only for:**
+
 - ESLint (`npm run lint`)
 - Prettier (`npm run format`)
 - `webextension-polyfill` package
@@ -122,33 +129,44 @@ bash build.sh
 - **Language:** Vanilla JavaScript. No TypeScript, no frameworks.
 - **Formatting:** Prettier (see `.prettierrc.json`). Run `npm run format` before committing.
 - **Linting:** ESLint (see `eslint.config.js`). Run `npm run lint` before committing.
-- **No bundler assumptions:** Do not introduce `import`/`export` ES module syntax unless the manifests are updated to support it. Use plain scripts.
-- **Cross-browser first:** All browser API calls must go through `webextension-polyfill`. Never call `chrome.*` directly without the polyfill wrapper.
+- **No bundler assumptions:** Do not introduce `import`/`export` ES module syntax unless the manifests are updated to
+  support it. Use plain scripts.
+- **Cross-browser first:** All browser API calls must go through `webextension-polyfill`. Never call `chrome.*` directly
+  without the polyfill wrapper.
 
 ---
 
 ## Permissions
 
-The extension requests minimal permissions (privacy-first). When suggesting new features, avoid introducing new manifest permissions unless absolutely necessary. Check both `manifest.chrome.json` and `manifest.firefox.json` when adding permissions.
+The extension requests minimal permissions (privacy-first). When suggesting new features, avoid introducing new manifest
+permissions unless absolutely necessary. Check both `manifest.chrome.json` and `manifest.firefox.json` when adding
+permissions.
 
-As of v1.3.1, the `tabs` permission was explicitly removed as unused — be aware this limits what tab metadata is directly accessible.
+As of v1.3.1, the `tabs` permission was explicitly removed as unused — be aware this limits what tab metadata is
+directly accessible.
 
 ---
 
 ## Known Constraints for LLM Assistants
 
-- **Do not assume a bundler is available.** There is no Webpack, Vite, or Rollup. Code must run as-is in the browser extension context.
-- **Content scripts run in an isolated world.** They cannot directly access the YTM page's JavaScript variables. Communication between `content.js` and `background.js` happens via `browser.runtime.sendMessage`.
-- **Service workers (MV3) have no DOM access and no persistent state.** Use `chrome.storage` / `browser.storage` for any state that needs to persist.
-- **MV2 background pages are persistent** but deprecated. Do not write code that assumes persistence in the MV3 background script.
-- **YouTube Music's DOM changes frequently.** Any selectors used to inject UI elements are brittle and may break with YTM updates. Add comments near selectors explaining what they target.
+- **Do not assume a bundler is available.** There is no Webpack, Vite, or Rollup. Code must run as-is in the browser
+  extension context.
+- **Content scripts run in an isolated world.** They cannot directly access the YTM page's JavaScript variables.
+  Communication between `content.js` and `background.js` happens via `browser.runtime.sendMessage`.
+- **Service workers (MV3) have no DOM access and no persistent state.** Use `chrome.storage` / `browser.storage` for any
+  state that needs to persist.
+- **MV2 background pages are persistent** but deprecated. Do not write code that assumes persistence in the MV3
+  background script.
+- **YouTube Music's DOM changes frequently.** Any selectors used to inject UI elements are brittle and may break with
+  YTM updates. Add comments near selectors explaining what they target.
 - **The `dist/` folder is gitignored.** Never commit build output.
 
 ---
 
 ## Testing
 
-There is no automated test suite for the extension logic itself. Manual testing is done by loading the unpacked extension:
+There is no automated test suite for the extension logic itself. Manual testing is done by loading the unpacked
+extension:
 
 - **Chrome/Edge:** `chrome://extensions` → Developer Mode → Load Unpacked → `dist/chrome/`
 - **Firefox:** `about:debugging` → Load Temporary Add-on → select `dist/firefox/manifest.json`
@@ -160,12 +178,12 @@ CI checks (GitHub Actions) cover only linting and formatting, not runtime behavi
 ## Contribution Notes for AI Assistants
 
 When helping with this project:
+
 1. **Always check both manifests** when changes touch permissions, background scripts, or browser actions.
 2. **Run `build.sh` mentally** — remember that `dist/` is generated. Source of truth is `src/`.
-3. **Prefer additive changes** — this is a published extension with real users. Avoid breaking existing window management behavior.
+3. **Prefer additive changes** — this is a published extension with real users. Avoid breaking existing window
+   management behavior.
 4. **Follow the existing vanilla JS style** — no framework introductions without maintainer discussion.
 5. **Check `CONTRIBUTING.md`** for PR-specific requirements before generating a pull request description.
 
 ---
-
- 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,26 +34,26 @@ ytm-miniplayer/
 ├── LICENSE                   # MIT
 ├── PULL_REQUEST_TEMPLATE.md
 ├── README.md
-├── build.sh                  # Build script: copies src + correct manifest into dist/
 ├── eslint.config.js          # ESLint config
 ├── manifest.chrome.json      # Manifest V3 — for Chrome and Edge
 ├── manifest.firefox.json     # Manifest V2 — for Firefox
 ├── package.json
 ├── package-lock.json
 ├── release_notes.md
-└── CONTEXT.md                # This file
+├── scripts/
+│   └── build.js                  # Build script: copies src + correct manifest into dist/
+└── CONTEXT.md                    # This file
 ```
 
 ### `src/` directory (primary working directory)
 
 The `src/` folder contains the actual extension logic. Key files to expect:
 
-| File            | Role                                                                                                                                      |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `content.js`    | Injected into `music.youtube.com`. Adds the toggle button to the DOM, handles click events.                                               |
-| `background.js` | Service worker (MV3) or background page (MV2). Manages `chrome.windows` / `browser.windows` API calls to pop out and collapse the window. |
-
-| `browser-polyfill.min.js' | `icons` |
+| `content.js` | Injected into `music.youtube.com`. Adds the toggle button to the DOM, handles click events. | |
+`background.js` | Service worker (MV3) or background page (MV2). Manages `chrome.windows` / `browser.windows` API calls
+to pop out and collapse the window. | | `browser-polyfill.min.js` | Bundled `webextension-polyfill` script used to
+normalize `browser.*`/`chrome.*` APIs across browsers. | | `icons/` | Extension icons referenced by the manifests and
+store listings. |
 
 ---
 
@@ -93,7 +93,7 @@ This project maintains **two separate manifests**:
 | Browser Action | `action`               | `browser_action`                             |
 | Target         | Chrome, Edge           | Firefox                                      |
 
-The `build.sh` script copies the right manifest as `manifest.json` into each browser's `dist/` folder.
+The build script copies the right manifest as `manifest.json` into each browser's `dist/` folder.
 
 **Firefox MV3 note:** Firefox has begun supporting Manifest V3 but with differences from Chrome's MV3 implementation.
 Migration is a known future task.
@@ -102,15 +102,15 @@ Migration is a known future task.
 
 ## Build System
 
-No bundler (no Webpack/Vite/Rollup). The build process is a plain bash script.
+No bundler (no Webpack/Vite/Rollup). The build process is a Node.js script.
 
 ```bash
-npm run build       # Runs build.sh
+npm run build       # Runs scripts/build.js
 # Or directly:
-bash build.sh
+node scripts/build.js
 ```
 
-**What `build.sh` does:**
+**What the build script does:**
 
 1. Copies `src/` into `dist/chrome/`, `dist/firefox/`, and `dist/edge/`
 2. Places the correct manifest into each folder
@@ -180,7 +180,7 @@ CI checks (GitHub Actions) cover only linting and formatting, not runtime behavi
 When helping with this project:
 
 1. **Always check both manifests** when changes touch permissions, background scripts, or browser actions.
-2. **Run `build.sh` mentally** — remember that `dist/` is generated. Source of truth is `src/`.
+2. **Remember that `dist/` is generated** — source of truth is `src/`. Run `npm run build` to regenerate it.
 3. **Prefer additive changes** — this is a published extension with real users. Avoid breaking existing window
    management behavior.
 4. **Follow the existing vanilla JS style** — no framework introductions without maintainer discussion.

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "node scripts/build.js",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "format": "prettier --write \"src/**/*.js\" \"*.json\" \"*.sh\" \"*.md\"",
-    "format:check": "prettier --check \"src/**/*.js\" \"*.json\" \"*.sh\" \"*.md\""
+    "format": "prettier --write \"src/**/*.js\" \"*.json\" \"*.md\"",
+    "format:check": "prettier --check \"src/**/*.js\" \"*.json\" \"*.md\""
   },
   "devDependencies": {
     "eslint": "^9.0.0",

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,8 +8,11 @@ All notable changes to the **YTM Mini Mode** extension will be documented in thi
 
 ### Added
 
-- **PWA Integration Support**: Standalone PWA windows now resize directly in-place when entering/exiting mini-player mode instead of closing the PWA and detaching into standard browser tabs. This preserves the independent PWA app icon in the macOS Dock and Command+Tab switcher.
-- **Robust Environment Detection**: Replaced unreliable media query checks with direct toolbar visibility verification to guarantee accurate detection of standalone vs. browser tab environments.
+- **PWA Integration Support**: Standalone PWA windows now resize directly in-place when entering/exiting mini-player
+  mode instead of closing the PWA and detaching into standard browser tabs. This preserves the independent PWA app icon
+  in the macOS Dock and Command+Tab switcher.
+- **Robust Environment Detection**: Replaced unreliable media query checks with direct toolbar visibility verification
+  to guarantee accurate detection of standalone vs. browser tab environments.
 
 ---
 

--- a/src/background.js
+++ b/src/background.js
@@ -46,10 +46,10 @@ messenger.runtime.onMessage.addListener(async (message, sender) => {
                     console.log("Background: PWA Reverting to normal...");
                     const dims = message.originalDimensions || {};
                     const targetState = dims.state || "normal";
-                    
+
                     // 1. Update state first
                     await messenger.windows.update(sender.tab.windowId, { state: targetState });
-                    
+
                     // 2. Update bounds only if the target state is normal
                     if (targetState === "normal") {
                         const bounds = {};
@@ -65,7 +65,7 @@ messenger.runtime.onMessage.addListener(async (message, sender) => {
                         if (typeof dims.top === "number") {
                             bounds.top = dims.top;
                         }
-                        
+
                         if (Object.keys(bounds).length > 0) {
                             await messenger.windows.update(sender.tab.windowId, bounds);
                         }

--- a/src/content.js
+++ b/src/content.js
@@ -320,7 +320,10 @@ function createNavButtons() {
         const messenger = typeof browser !== "undefined" ? browser : chrome;
 
         try {
-            const matchesStandalone = !window.toolbar.visible || window.matchMedia("(display-mode: standalone)").matches || window.matchMedia("(display-mode: minimal-ui)").matches;
+            const matchesStandalone =
+                !window.toolbar.visible ||
+                window.matchMedia("(display-mode: standalone)").matches ||
+                window.matchMedia("(display-mode: minimal-ui)").matches;
             let inMiniMode = false;
             try {
                 inMiniMode = sessionStorage.getItem("ytm_in_mini_mode") === "true";
@@ -338,7 +341,11 @@ function createNavButtons() {
                             height: window.outerHeight,
                             left: window.screenX,
                             top: window.screenY,
-                            state: window.outerWidth >= window.screen.availWidth - 20 && window.outerHeight >= window.screen.availHeight - 20 ? "maximized" : "normal"
+                            state:
+                                window.outerWidth >= window.screen.availWidth - 20 &&
+                                window.outerHeight >= window.screen.availHeight - 20
+                                    ? "maximized"
+                                    : "normal",
                         };
                         sessionStorage.setItem("ytm_original_dimensions", JSON.stringify(originalDimensions));
                     }


### PR DESCRIPTION
## Summary
Replaced the legacy bash-based build.sh script with a cross-platform Node.js build system (scripts/build.js) and updated the Prettier configurations in package.json to exclude the deleted *.sh glob. This prevents build/format command failures on Windows environments and ensures complete build portability across Windows, macOS, and Linux.

## Testing
Ran the following commands locally on Windows:

npm run lint - verified zero ESLint errors (only native warnings).
npm run format:check - confirmed all matched files adhere to Prettier styling rules.
npm run build - verified that Firefox, Chrome, Edge, and Opera builds and .zip archives are generated under /dist.

## Checklist
 I have tested the change locally.
 I have updated documentation if needed.
1:05 PM
